### PR TITLE
Deprecate the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DEPRECATED
 
-The library has been deprecated as of the PureScript 0.14 compiler release. The `Proxy` type has been migrated into the [`purescript-prelude`](https://github.com/purescript/purescript-prelude) library instead.
+The library is no longer maintained under this repository, it has been merged into [`purescript-prelude`](https://github.com/purescript/purescript-prelude).
 
 [The previous releases](https://github.com/purescript-deprecated/purescript-proxy/releases) will continue to work for older libraries that still depend on them.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
-# purescript-proxy
+# DEPRECATED
 
-[![Latest release](http://img.shields.io/bower/v/purescript-proxy.svg)](https://github.com/purescript/purescript-proxy/releases)
-[![Build Status](https://travis-ci.org/purescript/purescript-proxy.svg?branch=master)](https://travis-ci.org/purescript/purescript-proxy)
+The library has been deprecated as of the PureScript 0.14 compiler release. The `Proxy` type has been migrated into the [`purescript-prelude`](https://github.com/purescript/purescript-prelude) library instead.
 
-Value proxy for type inputs.
-
-## Installation
-
-```
-bower install purescript-proxy
-```
-
-## Documentation
-
-Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-proxy).
+[The previous releases](https://github.com/purescript-deprecated/purescript-proxy/releases) will continue to work for older libraries that still depend on them.

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git://github.com/purescript/purescript-proxy.git"
   },
+  "keywords": ["pursuit-deprecated"],
   "ignore": [
     "**/.*",
     "bower_components",


### PR DESCRIPTION
A variation on #9 which simply updates the README and adds the `pursuit-deprecated` keyword to the Bower file. Doing this allows us to make a release and upload that to Pursuit so that the deprecation is visible, after which point we can follow up by removing all the remaining files to leave only the deprecation notice README file.